### PR TITLE
feat: port Afnan DA/compiler COSY-compat fixes from origin/dev (1.10.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "rosy-cli"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "rosy-compiler"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "flate2",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "rosy-lib"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/rosy-cli/Cargo.toml
+++ b/rosy-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy-cli"
-version = "1.10.0"
+version = "1.10.1"
 edition = "2024"
 authors = ["hiibolt <rust@hiibolt.com>"]
 license = "MIT"
@@ -19,7 +19,7 @@ nightly-simd = ["rosy-compiler/nightly-simd"]
 [dependencies]
 anyhow.workspace = true
 clap = { version = "4.5", features = ["derive"] }
-rosy-compiler = { version = "1.10.0", path = "../rosy-compiler" }
+rosy-compiler = { version = "1.10.1", path = "../rosy-compiler" }
 tokio = { version = "1", features = ["rt", "io-std", "macros"] }
 
 [dev-dependencies]

--- a/rosy-compiler/Cargo.toml
+++ b/rosy-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy-compiler"
-version = "1.10.0"
+version = "1.10.1"
 edition = "2024"
 authors = ["hiibolt <rust@hiibolt.com>"]
 license = "MIT"
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 flate2 = "1"
 tar = "0.4"
-rosy-lib = { version = "1.10.0", path = "../rosy-lib" }
+rosy-lib = { version = "1.10.1", path = "../rosy-lib" }
 
 # LSP server
 tower-lsp = "0.20"

--- a/rosy-compiler/assets/output_template/main.rs
+++ b/rosy-compiler/assets/output_template/main.rs
@@ -9,8 +9,24 @@
 use rosy_lib::*;
 use anyhow::{Result, Context, ensure, bail};
 use num_complex::Complex64;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+static ROSY_PROGRAM_START: OnceLock<Instant> = OnceLock::new();
+
+fn rosy_init_timer() {
+	let _ = ROSY_PROGRAM_START.set(Instant::now());
+}
+
+fn rosy_elapsed_seconds() -> f64 {
+	ROSY_PROGRAM_START
+		.get_or_init(Instant::now)
+		.elapsed()
+		.as_secs_f64()
+}
 
 fn main_wrapper() -> Result<()> {
+	rosy_init_timer();
 	let start = std::time::Instant::now();
 	// <MPI_START>
 	let mut rosy_mpi_context_inner = RosyMPIContext::new()

--- a/rosy-compiler/build.rs
+++ b/rosy-compiler/build.rs
@@ -12,6 +12,7 @@ fn main() {
     println!("cargo:rerun-if-changed=src/program");
     println!("cargo:rerun-if-changed=src/compiler");
     println!("cargo:rerun-if-changed=../rosy-lib/src");
+    println!("cargo:rerun-if-changed=assets/output_template/main.rs");
 
     let out_dir = std::env::var("OUT_DIR").unwrap();
 

--- a/rosy-compiler/src/program/expressions/types/number.rs
+++ b/rosy-compiler/src/program/expressions/types/number.rs
@@ -10,6 +10,7 @@
 //! 42
 //! -7
 //! 1.23E-4
+//! .05
 //! ```
 //!
 //! All numeric literals produce the `RE` type.
@@ -102,8 +103,12 @@ mod tests {
         must_parse_as_number("0");
         must_parse_as_number("42");
         must_parse_as_number("-7");
+        must_parse_as_number("1.");
         must_parse_as_number("3.14");
         must_parse_as_number("-2.71828");
+        must_parse_as_number(".1");
+        must_parse_as_number(".05");
+        must_parse_as_number("-.05");
     }
 
     /// Scientific notation must match in ONE rule application, otherwise

--- a/rosy-compiler/src/program/statements/core/loop.rs
+++ b/rosy-compiler/src/program/statements/core/loop.rs
@@ -30,6 +30,7 @@ use crate::{
     resolve::*,
     transpile::*,
 };
+use pest::Parser;
 use rosy_lib::RosyType;
 
 /// AST node for the counted `LOOP i start end [step]; ... ENDLOOP;` statement.
@@ -73,14 +74,15 @@ impl FromRule for LoopStatement {
             let end_pair = start_loop_inner
                 .next()
                 .context("Missing third token `end_expr`!")?;
-            let end = Expr::from_rule(end_pair)
+            let end_text = end_pair.as_str().to_string();
+            let mut end = Expr::from_rule(end_pair)
                 .context("Failed to build `end` expression in `loop` statement!")?
                 .ok_or_else(|| {
                     anyhow::anyhow!("Expected expression for `end` in `loop` statement")
                 })?;
 
             // Optional step expression
-            let step = if let Some(step_pair) = start_loop_inner.next() {
+            let mut step = if let Some(step_pair) = start_loop_inner.next() {
                 if !matches!(step_pair.as_rule(), Rule::semicolon | Rule::end_loop) {
                     Some(
                         Expr::from_rule(step_pair)
@@ -97,6 +99,16 @@ impl FromRule for LoopStatement {
             } else {
                 None
             };
+
+            if step.is_none() {
+                if let Some((recovered_end, recovered_step)) =
+                    recover_trailing_signed_numeric_loop_step(&end_text)
+                        .context("Failed to recover signed numeric LOOP step")?
+                {
+                    end = recovered_end;
+                    step = Some(recovered_step);
+                }
+            }
 
             (iterator, start, end, step)
         };
@@ -126,6 +138,44 @@ impl FromRule for LoopStatement {
         }))
     }
 }
+
+fn parse_loop_expr_fragment(src: &str) -> Result<Expr> {
+    let trimmed = src.trim();
+    let mut pairs = CosyParser::parse(Rule::expr, trimmed)
+        .with_context(|| format!("Failed to parse LOOP expression fragment `{trimmed}`"))?;
+    let pair = pairs
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("Empty LOOP expression fragment `{trimmed}`"))?;
+    Expr::from_rule(pair)?
+        .ok_or_else(|| anyhow::anyhow!("Expected expression in LOOP fragment `{trimmed}`"))
+}
+
+fn recover_trailing_signed_numeric_loop_step(end_text: &str) -> Result<Option<(Expr, Expr)>> {
+    let trimmed = end_text.trim_end();
+    let Some(split_at) = trimmed.rfind(char::is_whitespace) else {
+        return Ok(None);
+    };
+
+    let step_text = trimmed[split_at..].trim_start();
+    let end_text = trimmed[..split_at].trim_end();
+    if end_text.is_empty() || !is_signed_numeric_literal(step_text) {
+        return Ok(None);
+    }
+
+    Ok(Some((
+        parse_loop_expr_fragment(end_text)?,
+        parse_loop_expr_fragment(step_text)?,
+    )))
+}
+
+fn is_signed_numeric_literal(src: &str) -> bool {
+    if !src.starts_with('-') {
+        return false;
+    }
+    let normalized = src.replace('D', "E").replace('d', "e");
+    normalized.parse::<f64>().is_ok()
+}
+
 impl TranspileableStatement for LoopStatement {
     fn register_typeslot_declaration(
         &self,

--- a/rosy-compiler/src/program/statements/core/procedure_call.rs
+++ b/rosy-compiler/src/program/statements/core/procedure_call.rs
@@ -27,12 +27,15 @@ use crate::{
     resolve::{ScopeContext, TypeResolver},
     transpile::*,
 };
+use pest::Parser;
+use rosy_lib::{RosyBaseType, RosyType};
 
 /// AST node for a procedure call statement.
 #[derive(Debug)]
 pub struct ProcedureCallStatement {
     pub name: String,
     pub args: Vec<Expr>,
+    raw: String,
 }
 
 impl FromRule for ProcedureCallStatement {
@@ -43,6 +46,7 @@ impl FromRule for ProcedureCallStatement {
             pair.as_rule()
         );
 
+        let raw = pair.as_str().to_string();
         let mut inner = pair.into_inner();
         let name = inner
             .next()
@@ -63,9 +67,136 @@ impl FromRule for ProcedureCallStatement {
             args.push(expr);
         }
 
-        Ok(Some(ProcedureCallStatement { name, args }))
+        Ok(Some(ProcedureCallStatement { name, args, raw }))
     }
 }
+
+fn split_raw_call_args(raw: &str, name: &str) -> Vec<String> {
+    let mut src = raw.trim();
+    if src.ends_with(';') {
+        src = &src[..src.len() - 1];
+    }
+    src = src.strip_prefix(name).unwrap_or(src).trim_start();
+
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let mut depth = 0i32;
+    let mut quote: Option<char> = None;
+
+    for ch in src.chars() {
+        if let Some(q) = quote {
+            current.push(ch);
+            if ch == q {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' => {
+                quote = Some(ch);
+                current.push(ch);
+            }
+            '(' | '[' => {
+                depth += 1;
+                current.push(ch);
+            }
+            ')' | ']' => {
+                depth -= 1;
+                current.push(ch);
+            }
+            ch if ch.is_whitespace() && depth == 0 => {
+                if !current.trim().is_empty() {
+                    args.push(current.trim().to_string());
+                    current.clear();
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if !current.trim().is_empty() {
+        args.push(current.trim().to_string());
+    }
+
+    args
+}
+
+fn parse_expr_arg(src: &str) -> Result<Expr> {
+    let pair = CosyParser::parse(Rule::expr, src)
+        .with_context(|| format!("Failed to parse procedure argument '{src}'"))?
+        .next()
+        .ok_or_else(|| anyhow!("Expected expression in procedure argument '{src}'"))?;
+    Expr::from_rule(pair)?
+        .ok_or_else(|| anyhow!("Expected expression in procedure argument '{src}'"))
+}
+
+fn procedure_arg_accepts(expected: &RosyType, provided: &RosyType) -> bool {
+    expected == provided
+        || (expected.dimensions == 0
+            && provided.dimensions == 0
+            && expected.base_type == RosyBaseType::DA
+            && provided.base_type == RosyBaseType::RE)
+}
+
+fn promote_arg_to_expected(
+    arg_output: &TranspilationOutput,
+    provided_type: &RosyType,
+    expected_type: &RosyType,
+) -> Option<String> {
+    if expected_type.dimensions == 0
+        && provided_type.dimensions == 0
+        && expected_type.base_type == RosyBaseType::DA
+        && provided_type.base_type == RosyBaseType::RE
+    {
+        Some(format!(
+            "DA::constant({})",
+            arg_output.as_owned(provided_type)
+        ))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn procedure_call_splits_negative_numeric_argument() {
+        let pair = CosyParser::parse(Rule::procedure_call, "DP 10 90 -0.05;")
+            .expect("procedure call should parse")
+            .next()
+            .expect("missing procedure_call pair");
+        let call = ProcedureCallStatement::from_rule(pair)
+            .expect("procedure call should build")
+            .expect("procedure call should be present");
+
+        assert_eq!(call.name, "DP");
+        assert_eq!(
+            split_raw_call_args(&call.raw, &call.name),
+            vec!["10", "90", "-0.05"]
+        );
+    }
+
+    #[test]
+    fn procedure_call_accepts_leading_dot_numeric_arguments() {
+        let pair = CosyParser::parse(Rule::procedure_call, "MQ .1 Q .05;")
+            .expect("procedure call should parse")
+            .next()
+            .expect("missing procedure_call pair");
+        let call = ProcedureCallStatement::from_rule(pair)
+            .expect("procedure call should build")
+            .expect("procedure call should be present");
+
+        assert_eq!(call.name, "MQ");
+        assert_eq!(
+            split_raw_call_args(&call.raw, &call.name),
+            vec![".1", "Q", ".05"]
+        );
+    }
+}
+
 impl Transpile for ProcedureCallStatement {
     fn transpile(
         &self,
@@ -92,13 +223,30 @@ impl Transpile for ProcedureCallStatement {
         }
         .clone();
 
+        let fallback_args;
+        let args = if proc_context.args.len() > self.args.len() {
+            let raw_args = split_raw_call_args(&self.raw, &self.name);
+            if raw_args.len() == proc_context.args.len() {
+                fallback_args = raw_args
+                    .iter()
+                    .map(|arg| parse_expr_arg(arg))
+                    .collect::<Result<Vec<_>>>()
+                    .map_err(|e| vec![e])?;
+                &fallback_args
+            } else {
+                &self.args
+            }
+        } else {
+            &self.args
+        };
+
         // Check that the number of arguments is correct
-        if proc_context.args.len() != self.args.len() {
+        if proc_context.args.len() != args.len() {
             return Err(vec![anyhow!(
                 "procedure '{}' expects {} arguments, but {} were provided!",
                 self.name,
                 proc_context.args.len(),
-                self.args.len()
+                args.len()
             )]);
         }
         let mut errors = Vec::new();
@@ -161,7 +309,7 @@ impl Transpile for ProcedureCallStatement {
         }
 
         // Pass 1 — record (a) bare-variable duplicates.
-        for (i, arg_expr) in self.args.iter().enumerate() {
+        for (i, arg_expr) in args.iter().enumerate() {
             if let Some(arg_name) = arg_expr.as_bare_variable_name() {
                 if first_occurrence.contains_key(arg_name) {
                     if let Some(var_data) = context.variables.get(arg_name) {
@@ -187,7 +335,7 @@ impl Transpile for ProcedureCallStatement {
         }
 
         // Add the manual arguments
-        for (i, arg_expr) in self.args.iter().enumerate() {
+        for (i, arg_expr) in args.iter().enumerate() {
             match arg_expr.transpile(context) {
                 Ok(arg_output) => {
                     // Check the type is correct
@@ -199,10 +347,19 @@ impl Transpile for ProcedureCallStatement {
                             "procedure '{}' expects {} arguments, but {} were provided!",
                             self.name,
                             proc_context.args.len(),
-                            self.args.len()
+                            args.len()
                         )])?
                         .r#type;
-                    if !types_compatible(&provided_type, &expected_type) {
+                    if let Some(promoted) =
+                        promote_arg_to_expected(&arg_output, &provided_type, &expected_type)
+                    {
+                        let temp_name = format!("__rosy_arg_tmp_{}", i);
+                        prelude_decls.push(format!("let mut {} = {};", temp_name, promoted));
+                        serialized_args.push(format!("&mut {}", temp_name));
+                        requested_variables.extend(arg_output.requested_variables);
+                    } else if !types_compatible(&provided_type, &expected_type)
+                        && !procedure_arg_accepts(&expected_type, &provided_type)
+                    {
                         if crate::syntax_config::is_cosy_syntax() {
                             if let Some(name) = arg_expr.as_bare_variable_name() {
                                 let scope = context

--- a/rosy-compiler/src/program/statements/io/pwtime.rs
+++ b/rosy-compiler/src/program/statements/io/pwtime.rs
@@ -82,10 +82,10 @@ impl Transpile for PwtimeStatement {
             }
         };
 
-        // Use the `start` Instant created at the top of main_wrapper() in the
-        // output template — same mechanism as CPUSEC.
+        // Use the timer helper from the output template so PWTIME works in
+        // generated function/procedure bodies as well as the main wrapper.
         let serialization = format!(
-            "{}{} = start.elapsed().as_secs_f64();",
+            "{}{} = rosy_elapsed_seconds();",
             dereference, output.serialization
         );
 

--- a/rosy-compiler/tests/constructs/statements/core/loop.rosy
+++ b/rosy-compiler/tests/constructs/statements/core/loop.rosy
@@ -4,11 +4,14 @@ BEGIN;
     LOOP I 1 + 0 5;
         SUM := SUM + I;
     ENDLOOP;
+    LOOP I 5 1 -2;
+        SUM := SUM + I;
+    ENDLOOP;
     WRITE 6 SUM;
 END;
 
 ======= expect
- 15.00000000000000
+ 24.00000000000000
 
 ======= fox
 BEGIN;
@@ -17,6 +20,9 @@ PROCEDURE RUN;
     VARIABLE SUM 1;
     SUM := 0;
     LOOP I 1 + 0 5;
+        SUM := SUM + I;
+    ENDLOOP;
+    LOOP I 5 1 -2;
         SUM := SUM + I;
     ENDLOOP;
     WRITE 6 SUM;

--- a/rosy-lib/Cargo.toml
+++ b/rosy-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy-lib"
-version = "1.10.0"
+version = "1.10.1"
 edition = "2024"
 authors = ["hiibolt <rust@hiibolt.com>"]
 license = "MIT"

--- a/rosy-lib/src/core/daprv.rs
+++ b/rosy-lib/src/core/daprv.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Result, Context, bail};
 
-use crate::taylor::{DA, get_config, get_runtime};
+use crate::taylor::{DA, cosy_display_rank, get_config, get_runtime};
 use crate::taylor::Monomial;
 
 /// Write an array of DA vectors in COSY INFINITY DAPRV format.
@@ -71,18 +71,13 @@ fn format_daprv(
         }
     }
 
-    // Sort by total order ascending, then reverse-lexicographic on exponents
-    all_monomials.sort_by(|m1, m2| {
-        m1.total_order.cmp(&m2.total_order)
-            .then_with(|| {
-                for i in (0..m1.exponents.len()).rev() {
-                    match m1.exponents[i].cmp(&m2.exponents[i]) {
-                        std::cmp::Ordering::Equal => continue,
-                        ord => return ord,
-                    }
-                }
-                std::cmp::Ordering::Equal
-            })
+    let sort_vars = current_vars.max(1).min(_max_vars).min(6);
+    all_monomials.sort_by_cached_key(|m| {
+        (
+            m.total_order,
+            cosy_display_rank(&m.exponents, sort_vars),
+            m.exponents,
+        )
     });
 
     // One block per component (single-column COSY format)

--- a/rosy-lib/src/core/display.rs
+++ b/rosy-lib/src/core/display.rs
@@ -1,5 +1,7 @@
 use crate::{RE, ST, LO, CM, VE, DA, CD};
-use crate::taylor::get_runtime;
+use crate::taylor::{MAX_VARS, cosy_display_rank, get_config, get_runtime};
+
+const ALL_COMPONENTS_ZERO: &str = "     ALL COMPONENTS ZERO\n     -------------------";
 
 fn sci(x: f64) -> (f64, i32) {
     if x == 0.0 {
@@ -176,24 +178,19 @@ impl RosyDisplay for &DA {
         // Get all coefficients
         let coeffs: Vec<_> = self.coeffs_iter();
         if coeffs.is_empty() {
-            return "     I  COEFFICIENT            ORDER EXPONENTS\n     1   0.000000000000000       0   0 0\n     -----------------------------------".to_string();
+            return ALL_COMPONENTS_ZERO.to_string();
         }
-        
-        // Sort by graded reverse lexicographic order (COSY format)
-        // First by total order, then by exponents in reverse lexicographic order
+
         let mut sorted = coeffs.clone();
-        sorted.sort_by(|(m1, _), (m2, _)| {
-            m1.total_order.cmp(&m2.total_order)
-                .then_with(|| {
-                    // Reverse lexicographic: compare from right to left
-                    for i in (0..m1.exponents.len()).rev() {
-                        match m1.exponents[i].cmp(&m2.exponents[i]) {
-                            std::cmp::Ordering::Equal => continue,
-                            ord => return ord,
-                        }
-                    }
-                    std::cmp::Ordering::Equal
-                })
+        let sort_vars = get_config()
+            .map(|config| config.num_vars)
+            .unwrap_or(MAX_VARS);
+        sorted.sort_by_cached_key(|(m, _)| {
+            (
+                m.total_order,
+                cosy_display_rank(&m.exponents, sort_vars),
+                m.exponents,
+            )
         });
         
         let mut output = String::new();
@@ -241,24 +238,19 @@ impl RosyDisplay for &CD {
         }
         
         if all_monomials.is_empty() {
-            return "     I  COEFFICIENTS                           ORDER EXPONENTS\n     1  0.000000000000000      0.000000000000000       0   0 0\n                                      ".to_string();
+            return ALL_COMPONENTS_ZERO.to_string();
         }
-        
-        // Sort by graded reverse lexicographic order (COSY format)
-        // First by total order, then by exponents in reverse lexicographic order
+
         let mut sorted: Vec<_> = all_monomials.into_iter().collect();
-        sorted.sort_by(|m1, m2| {
-            m1.total_order.cmp(&m2.total_order)
-                .then_with(|| {
-                    // Reverse lexicographic: compare from right to left
-                    for i in (0..m1.exponents.len()).rev() {
-                        match m1.exponents[i].cmp(&m2.exponents[i]) {
-                            std::cmp::Ordering::Equal => continue,
-                            ord => return ord,
-                        }
-                    }
-                    std::cmp::Ordering::Equal
-                })
+        let sort_vars = get_config()
+            .map(|config| config.num_vars)
+            .unwrap_or(MAX_VARS);
+        sorted.sort_by_cached_key(|m| {
+            (
+                m.total_order,
+                cosy_display_rank(&m.exponents, sort_vars),
+                m.exponents,
+            )
         });
         
         let mut output = String::new();
@@ -310,5 +302,19 @@ mod tests {
 
         assert!(displayed.contains(" 0.5469204E-002"), "got: {displayed:?}");
         assert!(displayed.contains(" 0.9378755E-010"), "got: {displayed:?}");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn zero_da_display_matches_cosy() {
+        crate::taylor::cleanup_taylor();
+        crate::taylor::init_taylor(2, 2).unwrap();
+        let value = crate::DA::zero();
+
+        assert_eq!(
+            value.rosy_display(),
+            "     ALL COMPONENTS ZERO\n     -------------------"
+        );
+        crate::taylor::cleanup_taylor();
     }
 }

--- a/rosy-lib/src/taylor.rs
+++ b/rosy-lib/src/taylor.rs
@@ -8,7 +8,7 @@ pub mod config;
 pub mod da;
 pub mod horner;
 
-pub use monomial::{Monomial, enumerate_monomials};
+pub use monomial::{Monomial, cosy_display_rank, enumerate_monomials};
 pub use config::{TaylorConfig, TaylorRuntime, init_taylor, cleanup_taylor, get_config, get_runtime, set_epsilon, set_truncation_order, set_filter_da, get_filter_da, set_weight_vector, dump_addressing_arrays};
 pub use da::DACoefficient;
 pub use horner::FixedMultiplier;

--- a/rosy-lib/src/taylor/da.rs
+++ b/rosy-lib/src/taylor/da.rs
@@ -307,7 +307,14 @@ impl<T: DACoefficient> DA<T> {
     pub fn trim(&mut self) {
         let rt = get_runtime().expect("Taylor system not initialized");
         let epsilon = rt.config.epsilon;
-        self.nonzero.retain(|&i| self.coeffs[i as usize].abs() > epsilon);
+        self.nonzero.retain(|&i| {
+            if self.coeffs[i as usize].abs() > epsilon {
+                true
+            } else {
+                self.coeffs[i as usize] = T::zero();
+                false
+            }
+        });
     }
 
     #[inline]
@@ -354,12 +361,25 @@ impl<T: DACoefficient> DA<T> {
         self.coeffs[0] = self.coeffs[0] + value;
         let is_nz = self.coeffs[0].abs() > epsilon;
 
-        if is_nz && !was_nz {
-            self.nonzero.push(0);
-        } else if !is_nz && was_nz {
-            if let Some(pos) = self.nonzero.iter().position(|&i| i == 0) {
-                self.nonzero.swap_remove(pos);
+        if is_nz {
+            let mut seen_constant = false;
+            self.nonzero.retain(|&i| {
+                if i == 0 {
+                    if seen_constant {
+                        false
+                    } else {
+                        seen_constant = true;
+                        true
+                    }
+                } else {
+                    true
+                }
+            });
+            if !seen_constant {
+                self.nonzero.push(0);
             }
+        } else if was_nz || self.nonzero.contains(&0) {
+            self.nonzero.retain(|&i| i != 0);
             self.coeffs[0] = T::zero();
         }
     }
@@ -417,10 +437,14 @@ impl<T: DACoefficient> Add<&DA<T>> for &DA<T> {
         }
 
         let mut nonzero = Vec::with_capacity(self.nonzero.len() + rhs.nonzero.len());
+        let mut result_set = vec![0u64; words];
         for &i in &self.nonzero {
             let iu = i as usize;
             if orders[iu] <= max_order && coeffs[iu].abs() > epsilon {
-                nonzero.push(i);
+                if result_set[iu / 64] & (1u64 << (iu % 64)) == 0 {
+                    nonzero.push(i);
+                    result_set[iu / 64] |= 1u64 << (iu % 64);
+                }
             } else {
                 coeffs[iu] = T::zero();
             }
@@ -429,7 +453,10 @@ impl<T: DACoefficient> Add<&DA<T>> for &DA<T> {
             let ju = j as usize;
             if self_set[ju / 64] & (1u64 << (ju % 64)) == 0 {
                 if orders[ju] <= max_order && coeffs[ju].abs() > epsilon {
-                    nonzero.push(j);
+                    if result_set[ju / 64] & (1u64 << (ju % 64)) == 0 {
+                        nonzero.push(j);
+                        result_set[ju / 64] |= 1u64 << (ju % 64);
+                    }
                 } else {
                     coeffs[ju] = T::zero();
                 }
@@ -520,10 +547,14 @@ impl<T: DACoefficient> Sub<&DA<T>> for &DA<T> {
         }
 
         let mut nonzero = Vec::with_capacity(self.nonzero.len() + rhs.nonzero.len());
+        let mut result_set = vec![0u64; words];
         for &i in &self.nonzero {
             let iu = i as usize;
             if orders[iu] <= max_order && coeffs[iu].abs() > epsilon {
-                nonzero.push(i);
+                if result_set[iu / 64] & (1u64 << (iu % 64)) == 0 {
+                    nonzero.push(i);
+                    result_set[iu / 64] |= 1u64 << (iu % 64);
+                }
             } else {
                 coeffs[iu] = T::zero();
             }
@@ -532,7 +563,10 @@ impl<T: DACoefficient> Sub<&DA<T>> for &DA<T> {
             let ju = j as usize;
             if self_set[ju / 64] & (1u64 << (ju % 64)) == 0 {
                 if orders[ju] <= max_order && coeffs[ju].abs() > epsilon {
-                    nonzero.push(j);
+                    if result_set[ju / 64] & (1u64 << (ju % 64)) == 0 {
+                        nonzero.push(j);
+                        result_set[ju / 64] |= 1u64 << (ju % 64);
+                    }
                 } else {
                     coeffs[ju] = T::zero();
                 }
@@ -748,10 +782,15 @@ impl<T: DACoefficient> Mul<T> for &DA<T> {
             return Ok(DA::zero());
         }
         let mut coeffs = T::pool_alloc(rt.num_monomials);
+        let mut nonzero = Vec::with_capacity(self.nonzero.len());
         for &i in &self.nonzero {
-            coeffs[i as usize] = self.coeffs[i as usize] * rhs;
+            let scaled = self.coeffs[i as usize] * rhs;
+            if scaled.abs() > epsilon {
+                coeffs[i as usize] = scaled;
+                nonzero.push(i);
+            }
         }
-        Ok(DA { coeffs, nonzero: self.nonzero.clone() })
+        Ok(DA { coeffs, nonzero })
     }
 }
 
@@ -976,6 +1015,44 @@ impl DA<Complex64> {
             }
         }
         DA { coeffs, nonzero }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    use crate::taylor::config::{cleanup_taylor, init_taylor, set_epsilon};
+
+    #[test]
+    #[serial]
+    fn scalar_multiply_prunes_coefficients_below_runtime_epsilon() {
+        cleanup_taylor();
+        init_taylor(2, 2).unwrap();
+        set_epsilon(1e-16).unwrap();
+
+        let x = DA::<f64>::variable(1).unwrap();
+        let scaled = (&x * 8.0e-17).unwrap();
+
+        assert!(scaled.is_zero());
+
+        cleanup_taylor();
+    }
+
+    #[test]
+    #[serial]
+    fn scalar_multiply_keeps_coefficients_above_runtime_epsilon() {
+        cleanup_taylor();
+        init_taylor(2, 2).unwrap();
+        set_epsilon(1e-16).unwrap();
+
+        let x = DA::<f64>::variable(1).unwrap();
+        let scaled = (&x * 2.0e-16).unwrap();
+
+        assert_eq!(scaled.num_terms(), 1);
+
+        cleanup_taylor();
     }
 }
 

--- a/rosy-lib/src/taylor/monomial.rs
+++ b/rosy-lib/src/taylor/monomial.rs
@@ -94,6 +94,78 @@ pub fn enumerate_monomials(max_order: u32, num_vars: u32, weights: Option<&[u32]
     result
 }
 
+/// COSY DAPRV/DA display rank for a monomial at a fixed total order.
+///
+/// COSY recursively splits the active variables into left/right blocks. For a
+/// four-variable map this yields second-order terms as:
+/// 2000, 1100, 0200, 1010, 0110, 1001, 0101, 0020, 0011, 0002.
+pub fn cosy_display_rank(exponents: &[u8], active_vars: usize) -> usize {
+    let active_vars = active_vars.min(exponents.len());
+    if active_vars == 0 {
+        return 0;
+    }
+
+    let degree = exponents[..active_vars]
+        .iter()
+        .map(|&exp| exp as usize)
+        .sum();
+    let mut ordered = Vec::new();
+    enumerate_cosy_exponents(active_vars, degree, &mut ordered);
+    ordered
+        .iter()
+        .position(|candidate| candidate.as_slice() == &exponents[..active_vars])
+        .unwrap_or(usize::MAX)
+}
+
+fn enumerate_cosy_exponents(num_vars: usize, degree: usize, result: &mut Vec<Vec<u8>>) {
+    if num_vars == 0 {
+        if degree == 0 {
+            result.push(Vec::new());
+        }
+        return;
+    }
+
+    if num_vars == 1 {
+        result.push(vec![degree as u8]);
+        return;
+    }
+
+    let left_vars = (num_vars + 1) / 2;
+    let right_vars = num_vars - left_vars;
+
+    for right_degree in 0..=degree {
+        if right_degree == 0 {
+            let mut left_terms = Vec::new();
+            enumerate_cosy_exponents(left_vars, degree, &mut left_terms);
+            for left in left_terms {
+                let mut term = left;
+                term.resize(num_vars, 0);
+                result.push(term);
+            }
+        } else if right_degree == degree {
+            let mut right_terms = Vec::new();
+            enumerate_cosy_exponents(right_vars, degree, &mut right_terms);
+            for right in right_terms {
+                let mut term = vec![0; left_vars];
+                term.extend(right);
+                result.push(term);
+            }
+        } else {
+            let mut right_terms = Vec::new();
+            let mut left_terms = Vec::new();
+            enumerate_cosy_exponents(right_vars, right_degree, &mut right_terms);
+            enumerate_cosy_exponents(left_vars, degree - right_degree, &mut left_terms);
+            for right in &right_terms {
+                for left in &left_terms {
+                    let mut term = left.clone();
+                    term.extend(right);
+                    result.push(term);
+                }
+            }
+        }
+    }
+}
+
 fn enumerate_monomials_recursive(
     remaining_order: u32,
     num_vars: usize,
@@ -223,5 +295,25 @@ mod tests {
 
         assert!(m1 < m2);
         assert!(m2 < m3);
+    }
+
+    #[test]
+    fn test_cosy_display_rank_four_vars_degree_two() {
+        let expected = [
+            [2, 0, 0, 0],
+            [1, 1, 0, 0],
+            [0, 2, 0, 0],
+            [1, 0, 1, 0],
+            [0, 1, 1, 0],
+            [1, 0, 0, 1],
+            [0, 1, 0, 1],
+            [0, 0, 2, 0],
+            [0, 0, 1, 1],
+            [0, 0, 0, 2],
+        ];
+
+        for (rank, exponents) in expected.iter().enumerate() {
+            assert_eq!(cosy_display_rank(exponents, 4), rank);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Afnan's `origin/dev` diverged from `master` before the crate split and a pile of later COSY-compat work. I went through her unique commits one by one rather than merging the old tree.

**Already on master (skipped):**
- `.gitmodules` / libcosy removal
- pest `empty_literal` vs `.05` numbers
- TRANSPORT id as digit-as-variable (`222` = x2^3)
- LOOP while-loop codegen
- CPUSEC as `rosy_cpu_time()` (her wall-clock helper would have undone that)

**Ported onto current crates:**
- COSY display rank for DA/CD/DAPRV term order, plus `ALL COMPONENTS ZERO`
- DA `trim` zeros dropped coeffs, add/sub nonzero dedup, scalar-mul epsilon prune
- LOOP recovers a trailing signed numeric step (`LOOP I 5 1 -2`)
- Procedure calls re-split raw args when pest ate a leading `-`/`.`, and promote `RE` → `DA::constant`
- PWTIME uses a process-wide elapsed timer so it works inside procedures

Version bump: 1.10.0 → 1.10.1.

## Test plan
- [x] `cargo test --workspace`
- [x] `rosy test -f loop`
- [x] `rosy test -f daprv`
- [x] `rosy test -f procedure_call`
- [x] `rosy test -f danot`